### PR TITLE
Fixed the card text for Eli Selkin card in Engage's Project page was: displayed nonuniformly 

### DIFF
--- a/_sass/components/_project-page.scss
+++ b/_sass/components/_project-page.scss
@@ -410,7 +410,7 @@
 }
 
 .leader-description {
-  padding: 0px 12px;
+  padding: 0px 61px;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #7429

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - I resolved the issue by adjusting the padding to 0px 61px, ensuring it didn't impact the landscape view or responsiveness across mobile and web platforms. I also verified that the changes-maintained user-friendliness and dynamic functionality throughout.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - I addressed this issue to ensure it aligns with the user-friendly standards we uphold at HackForLA


### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/b4aa5294-1181-458f-b67b-c2c39bb0ca21)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/c6deb879-4215-4b89-8f13-b6ed9b5b5dbd)

</details>
